### PR TITLE
Improve export file library.map.

### DIFF
--- a/agent/lib/library.map
+++ b/agent/lib/library.map
@@ -19,7 +19,7 @@
     statsinfo_meminfo;
     statsinfo_rusage;
     statsinfo_rusage_reset;
-	statsinfo_rusage_info;
+    statsinfo_rusage_info;
     statsinfo_sample;
     statsinfo_sample_wait_sampling;
     statsinfo_sample_wait_sampling_reset;
@@ -29,6 +29,5 @@
     statsinfo_stop;
     statsinfo_tablespaces;
     statsinfo_wait_sampling_profile;
-    statsinfo_wait_sampling_reset_profile;
   local: *;
 };


### PR DESCRIPTION
This commit removes a symbol for a function that is no longer used from the export file library.map. Additionally, it replaces a tab character that was accidentally added with four spaces. These changes improve the clarity and consistency of the export file.