### PR TITLE
Modified a function-alert test.

### DIFF
--- a/test/expected/function-alert.out
+++ b/test/expected/function-alert.out
@@ -57,6 +57,7 @@ UPDATE 1
 UPDATE 1
 UPDATE 1
 UPDATE 1
+UPDATE 1
                                                           alert                                                           
 --------------------------------------------------------------------------------------------------------------------------
  free disk space ratio at 'pg_default' fell below threshold in snapshot 'xxx' --- 19 % (threshold = 20 %)

--- a/test/script/function-alert.sh
+++ b/test/script/function-alert.sh
@@ -160,6 +160,7 @@ UPDATE statsrepo.alert SET disk_remain_percent = default;
 UPDATE statsrepo.alert SET (loadavg_1min, loadavg_5min, loadavg_15min) = (default, default, default);
 UPDATE statsrepo.alert SET swap_size = default;
 UPDATE statsrepo.tablespace SET (avail, total) = (1.9*1024^3, 10*1024^3) WHERE name = 'pg_default' AND snapid = 2;
+UPDATE statsrepo.tablespace SET (avail, total) = (9.0*1024^3, 10*1024^3) WHERE name = 'pg_global' AND snapid = 2;
 UPDATE statsrepo.loadavg SET (loadavg1, loadavg5, loadavg15) = (7.1, 6.1, 5.1) WHERE snapid = 2;
 UPDATE statsrepo.memory SET swap = 1000001 WHERE snapid = 2;
 EOF


### PR DESCRIPTION
Hello.

In Present, the function-alert test is failed when the volume to place a data redictory is small, because an alert is triggered when a remaining volume of a pg_global falls below a threshold.

The places that cause the test to fail are follows.
The test overwrites a remaining volume of  pg_default to make it look smaller for triger a alert.
It is set in the following places.
https://github.com/ossc-db/pg_statsinfo/blob/67e35c39e659860e5eb89efe45692a91971c5df3/test/script/function-alert.sh#L162

And the log output at this time is follows.
And the second line is the log that causes the test to failed.

```
free disk space ratio at 'pg_default' fell below threshold in snapshot 'xxx' --- 19 % (threshold = 20 %)
free disk space ratio at 'pg_global' fell below threshold in snapshot 'xxx' --- 18.8 % (threshold = 20 %)
```

Test results should not diffrent by environment, so I propose this solution.
It is the test overwrites a remaining volume of pg_global to make it look bigger for not triger a alert.
This is made alerted in only pg_default.

As a side note, another solution is eixsted for this problem.
It is the test overwrites a remaining volume of  pg_global to make it look smaller for triger a alert.
This is made alerted in both pg_default and pg_blobal.
But, the purpose of this test is to confirm that an alert will be triggered when a remaining volume is below the threshold, so it only needs to be confirmed in one tablespace.

