### PR TITLE
Support PostgreSQL 17.

### DIFF
--- a/agent/bin/collector_sql.h
+++ b/agent/bin/collector_sql.h
@@ -101,8 +101,8 @@ SELECT \
 	s.local_blks_written, \
 	s.temp_blks_read, \
 	s.temp_blks_written, \
-	s.blk_read_time, \
-	s.blk_write_time, \
+	s.shared_blk_read_time, \
+	s.shared_blk_write_time, \
 	s.temp_blk_read_time, \
 	s.temp_blk_write_time \
 FROM \
@@ -199,8 +199,6 @@ WHERE \
 SELECT \
 	buffers_clean, \
 	maxwritten_clean, \
-	buffers_backend, \
-	buffers_backend_fsync, \
 	buffers_alloc \
 FROM \
 	pg_stat_bgwriter"

--- a/agent/bin/writer_sql.h
+++ b/agent/bin/writer_sql.h
@@ -47,7 +47,7 @@ INSERT INTO statsrepo.plan \
 INSERT INTO statsrepo.lock VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)"
 
 #define SQL_INSERT_BGWRITER "\
-INSERT INTO statsrepo.bgwriter VALUES ($1, $2, $3, $4, $5, $6)"
+INSERT INTO statsrepo.bgwriter VALUES ($1, $2, $3, $4)"
 
 #define SQL_INSERT_REPLICATION "\
 INSERT INTO statsrepo.replication VALUES \

--- a/reporter/report.c
+++ b/reporter/report.c
@@ -667,10 +667,6 @@ report_instance_activity(PGconn *conn, ReportScope *scope, FILE *out)
 	res = pgut_execute(conn, SQL_SELECT_BGWRITER_STATS, lengthof(params), params);
 	fprintf(out, "Written Buffers By BGWriter (Average) : %s buffers/s\n", PQgetvalue(res, 0, 0));
 	fprintf(out, "Written Buffers By BGWriter (Maximum) : %s buffers/s\n", PQgetvalue(res, 0, 1));
-	fprintf(out, "Written Buffers By Backend (Average)  : %s buffers/s\n", PQgetvalue(res, 0, 2));
-	fprintf(out, "Written Buffers By Backend (Maximum)  : %s buffers/s\n", PQgetvalue(res, 0, 3));
-	fprintf(out, "Backend Executed fsync (Average)      : %s sync/s\n", PQgetvalue(res, 0, 4));
-	fprintf(out, "Backend Executed fsync (Maximum)      : %s sync/s\n\n", PQgetvalue(res, 0, 5));
 	PQclear(res);
 
 	fprintf(out, "/** Transaction Increase Tendency **/\n");

--- a/test/expected/function-report.out
+++ b/test/expected/function-report.out
@@ -541,11 +541,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -614,11 +609,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -687,11 +677,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -760,11 +745,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -833,11 +813,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -906,11 +881,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -3422,11 +3392,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -3898,11 +3863,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -4374,11 +4334,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -4850,11 +4805,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -5326,11 +5276,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -5802,11 +5747,6 @@ Average                   25.5      (36.4 %)          12.8      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 20.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 30.000 buffers/s
-Written Buffers By Backend (Average)  : 200.000 buffers/s
-Written Buffers By Backend (Maximum)  : 300.000 buffers/s
-Backend Executed fsync (Average)      : 2.000 sync/s
-Backend Executed fsync (Maximum)      : 3.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase
@@ -6475,11 +6415,6 @@ Average                  300.5      (36.4 %)         150.3      (18.2 %)        
 -----------------------------------
 Written Buffers By BGWriter (Average) : 0.000 buffers/s
 Written Buffers By BGWriter (Maximum) : 0.000 buffers/s
-Written Buffers By Backend (Average)  : 0.000 buffers/s
-Written Buffers By Backend (Maximum)  : 0.000 buffers/s
-Backend Executed fsync (Average)      : 0.000 sync/s
-Backend Executed fsync (Maximum)      : 0.000 sync/s
-
 /** Transaction Increase Tendency **/
 -----------------------------------
 DateTime          XID Increase

--- a/test/expected/function-snapshot.out
+++ b/test/expected/function-snapshot.out
@@ -41,13 +41,13 @@ vacuumdb: vacuuming database "template1"
 /**--- Statistics of column ---**/
  snapid | database | table | column  | attnum |  type   | stattarget | storage | isnotnull | isdropped | date | avg_width | n_distinct | correlation 
 --------+----------+-------+---------+--------+---------+------------+---------+-----------+-----------+------+-----------+------------+-------------
-      1 | db01     | tbl01 | id      |      1 | integer |         -1 | p       | t         | f         | xxx  | xxx       | xxx        | xxx
-      1 | db01     | tbl01 | name    |      2 | text    |         -1 | x       | f         | f         | xxx  | xxx       | xxx        | xxx
-      1 | db01     | tbl01 | age     |      3 | integer |         -1 | p       | f         | f         | xxx  | xxx       | xxx        | xxx
-      1 | db01     | tbl02 | id      |      1 | integer |         -1 | p       | t         | f         | xxx  | xxx       | xxx        | 
-      1 | db01     | tbl02 | name    |      2 | text    |         -1 | x       | f         | f         | xxx  | xxx       | xxx        | 
-      1 | db01     | tbl02 | age     |      3 | integer |         -1 | p       | f         | f         | xxx  | xxx       | xxx        | 
-      1 | db01     | tbl02 | address |      4 | text    |         -1 | x       | f         | f         | xxx  | xxx       | xxx        | 
+      1 | db01     | tbl01 | id      |      1 | integer |            | p       | t         | f         | xxx  | xxx       | xxx        | xxx
+      1 | db01     | tbl01 | name    |      2 | text    |            | x       | f         | f         | xxx  | xxx       | xxx        | xxx
+      1 | db01     | tbl01 | age     |      3 | integer |            | p       | f         | f         | xxx  | xxx       | xxx        | xxx
+      1 | db01     | tbl02 | id      |      1 | integer |            | p       | t         | f         | xxx  | xxx       | xxx        | 
+      1 | db01     | tbl02 | name    |      2 | text    |            | x       | f         | f         | xxx  | xxx       | xxx        | 
+      1 | db01     | tbl02 | age     |      3 | integer |            | p       | f         | f         | xxx  | xxx       | xxx        | 
+      1 | db01     | tbl02 | address |      4 | text    |            | x       | f         | f         | xxx  | xxx       | xxx        | 
 (7 rows)
 
 /**--- Statistics of index ---**/
@@ -109,6 +109,7 @@ vacuumdb: vacuuming database "template1"
       1 | pg_create_subscription      | xxx
       1 | pg_database_owner           | xxx
       1 | pg_execute_server_program   | xxx
+      1 | pg_maintain                 | xxx
       1 | pg_monitor                  | xxx
       1 | pg_read_all_data            | xxx
       1 | pg_read_all_settings        | xxx
@@ -121,7 +122,7 @@ vacuumdb: vacuuming database "template1"
       1 | pg_write_server_files       | xxx
       1 | postgres                    | xxx
       1 | user01                      | xxx
-(16 rows)
+(17 rows)
 
 /**--- GUC setting ---**/
  snapid |       name        | setting | unit |       source       
@@ -189,21 +190,21 @@ DROP TABLE
 
 /**--- Statistics of query ---**/
 /***-- pg_stat_statements is not installed --***/
- snapid | dbid | userid | queryid | query | plans | total_plan_time | calls | total_exec_time | rows | shared_blks_hit | shared_blks_read | shared_blks_dirtied | shared_blks_written | local_blks_hit | local_blks_read | local_blks_dirtied | local_blks_written | temp_blks_read | temp_blks_written | blk_read_time | blk_write_time | temp_blk_read_time | temp_blk_write_time 
---------+------+--------+---------+-------+-------+-----------------+-------+-----------------+------+-----------------+------------------+---------------------+---------------------+----------------+-----------------+--------------------+--------------------+----------------+-------------------+---------------+----------------+--------------------+---------------------
+ snapid | dbid | userid | queryid | query | plans | total_plan_time | calls | total_exec_time | rows | shared_blks_hit | shared_blks_read | shared_blks_dirtied | shared_blks_written | local_blks_hit | local_blks_read | local_blks_dirtied | local_blks_written | temp_blks_read | temp_blks_written | shared_blk_read_time | shared_blk_write_time | temp_blk_read_time | temp_blk_write_time 
+--------+------+--------+---------+-------+-------+-----------------+-------+-----------------+------+-----------------+------------------+---------------------+---------------------+----------------+-----------------+--------------------+--------------------+----------------+-------------------+----------------------+-----------------------+--------------------+---------------------
 (0 rows)
 
 /***-- pg_stat_statements is installed --***/
 CREATE EXTENSION
- snapid | database |  role  |             query              | plans | total_plan_time | calls | total_exec_time | rows | shared_blks_hit | shared_blks_read | shared_blks_dirtied | shared_blks_written | local_blks_hit | local_blks_read | local_blks_dirtied | local_blks_written | temp_blks_read | temp_blks_written | blk_read_time | blk_write_time | temp_blk_read_time | temp_blk_write_time 
---------+----------+--------+--------------------------------+-------+-----------------+-------+-----------------+------+-----------------+------------------+---------------------+---------------------+----------------+-----------------+--------------------+--------------------+----------------+-------------------+---------------+----------------+--------------------+---------------------
-      8 | db01     | user01 | SELECT schema01.func01($1, $2) |     0 | xxx             |   200 | xxx             | xxx  | xxx             | xxx              | xxx                 | xxx                 | xxx            | xxx             | xxx                | xxx                | xxx            | xxx               | xxx           | xxx            | xxx                | xxx
+ snapid | database |  role  |             query              | plans | total_plan_time | calls | total_exec_time | rows | shared_blks_hit | shared_blks_read | shared_blks_dirtied | shared_blks_written | local_blks_hit | local_blks_read | local_blks_dirtied | local_blks_written | temp_blks_read | temp_blks_written | shared_blk_read_time | shared_blk_write_time | temp_blk_read_time | temp_blk_write_time 
+--------+----------+--------+--------------------------------+-------+-----------------+-------+-----------------+------+-----------------+------------------+---------------------+---------------------+----------------+-----------------+--------------------+--------------------+----------------+-------------------+----------------------+-----------------------+--------------------+---------------------
+      8 | db01     | user01 | SELECT schema01.func01($1, $2) |     0 | xxx             |   200 | xxx             | xxx  | xxx             | xxx              | xxx                 | xxx                 | xxx            | xxx             | xxx                | xxx                | xxx            | xxx               | xxx                  | xxx                   | xxx                | xxx
 (1 row)
 
 /**--- Statistics of BGWriter ---**/
- snapid | buffers_clean | maxwritten_clean | buffers_backend | buffers_backend_fsync | buffers_alloc 
---------+---------------+------------------+-----------------+-----------------------+---------------
-      8 | xxx           | xxx              | xxx             | xxx                   | xxx
+ snapid | buffers_clean | maxwritten_clean | buffers_alloc 
+--------+---------------+------------------+---------------
+      8 | xxx           | xxx              | xxx
 (1 row)
 
 /**--- Statistics of rusage ---**/

--- a/test/script/function-snapshot.sh
+++ b/test/script/function-snapshot.sh
@@ -593,8 +593,8 @@ SELECT
 	CASE WHEN s.local_blks_written IS NOT NULL THEN 'xxx' END AS local_blks_written,
 	CASE WHEN s.temp_blks_read IS NOT NULL THEN 'xxx' END AS temp_blks_read,
 	CASE WHEN s.temp_blks_written IS NOT NULL THEN 'xxx' END AS temp_blks_written,
-	CASE WHEN s.blk_read_time IS NOT NULL THEN 'xxx' END AS blk_read_time,
-	CASE WHEN s.blk_write_time IS NOT NULL THEN 'xxx' END AS blk_write_time,
+	CASE WHEN s.shared_blk_read_time IS NOT NULL THEN 'xxx' END AS shared_blk_read_time,
+	CASE WHEN s.shared_blk_write_time IS NOT NULL THEN 'xxx' END AS shared_blk_write_time,
 	CASE WHEN s.temp_blk_read_time IS NOT NULL THEN 'xxx' END AS temp_blk_read_time,
 	CASE WHEN s.temp_blk_write_time IS NOT NULL THEN 'xxx' END AS temp_blk_write_time
 FROM
@@ -617,8 +617,6 @@ SELECT
 	snapid,
 	CASE WHEN buffers_clean IS NOT NULL THEN 'xxx' END AS buffers_clean,
 	CASE WHEN maxwritten_clean IS NOT NULL THEN 'xxx' END AS maxwritten_clean,
-	CASE WHEN buffers_backend IS NOT NULL THEN 'xxx' END AS buffers_backend,
-	CASE WHEN buffers_backend_fsync IS NOT NULL THEN 'xxx' END AS buffers_backend_fsync,
 	CASE WHEN buffers_alloc IS NOT NULL THEN 'xxx' END AS buffers_alloc
 FROM
 	statsrepo.bgwriter

--- a/test/script/inputdata/statsrepo-inputdata.sql
+++ b/test/script/inputdata/statsrepo-inputdata.sql
@@ -81,10 +81,10 @@ $$
 	--
 	-- Data for Name: bgwriter; Type: TABLE DATA; Schema: statsrepo; Owner: postgres
 	--
-	INSERT INTO statsrepo.bgwriter VALUES ($6, 0, 0, 0, 0, 0);
-	INSERT INTO statsrepo.bgwriter VALUES ($6 + 1, 600, 6, 6000, 60, 60000);
-	INSERT INTO statsrepo.bgwriter VALUES ($6 + 2, 2400, 24, 24000, 240, 240000);
-	INSERT INTO statsrepo.bgwriter VALUES ($6 + 3, 3600, 36, 36000, 360, 360000);
+	INSERT INTO statsrepo.bgwriter VALUES ($6, 0, 0, 0);
+	INSERT INTO statsrepo.bgwriter VALUES ($6 + 1, 600, 6, 60000);
+	INSERT INTO statsrepo.bgwriter VALUES ($6 + 2, 2400, 24, 240000);
+	INSERT INTO statsrepo.bgwriter VALUES ($6 + 3, 3600, 36, 360000);
 
 	--
 	-- Data for Name: autovacuum_cancel; Type: TABLE DATA; Schema: statsrepo; Owner: postgres


### PR DESCRIPTION
This pull request introduces several enhancements to support PostgreSQL 17 in pg_statsinfo. 
The key changes include:

Improved Backend Identification: Replaced MyBackendId with MyProcNumber for more accurate backend identification in PostgreSQL 17.

Removal of Obsolete Field: Removed the tuplestore_donestoring field, which is no longer relevant in PostgreSQL 17.

Refined Background Writer Metrics: Removed the buffers_backend and buffers_backend_fsync fields from pg_stat_bgwriter to reflect changes in PostgreSQL 17's background writer.

Updated Shared Block I/O Metrics: Renamed the blk_{read|write}_time columns in pg_stat_statements to shared_blk_{read|write}_time to align with the updated metrics in PostgreSQL 17.

Adjusted Default Value: Changed the default value of the attstattarget column in pg_attribute from -1 to NULL to match the PostgreSQL 17 behavior.

Enhanced Testing: Added test cases to ensure compatibility with the pg_maintain role.

This update ensures full compatibility with PostgreSQL 17 and improves the accuracy and relevance of the collected statistics. All changes have been thoroughly tested.
Please review the changes and let me know if you have any questions or concerns. Thank you!