### PR TITLE
In the case of pg_store_plans, there is a note in Q8, but I added it …

### DIFF
--- a/doc/pg_statsinfo-ja.md
+++ b/doc/pg_statsinfo-ja.md
@@ -1341,7 +1341,16 @@ pg_statsinfo
 は「インスタンスID」でインスタンスを識別します。インスタンスIDは監視対象サーバのホスト名、ポート番号とpg_controldata
 が表示するデータベースシステム識別子から生成されます。この中でマスタのホスト名はフェイルオーバーの際に変わることが普通なためこのようになります。
 
+#### Q11. pg_stat_statements をインストールしているのにレポートでプランの統計情報が出てきません。
   
+pg_stat_statements が public 以外のスキーマにインストールされている可能性があります。
+この場合はログを確認すると繰り返し以下の様なエラーが記録されているはずです。
+
+ERROR: pg_statsinfo: query failed: ERROR:  relation "pg_stat_statements" does not exist
+
+この場合は一旦 DROP EXTENSION したのち、明示的にスキーマを public と指定して CREATE EXTENSION を実行しなおしてください。
+
+CREATE EXTENSION pg_stat_statements SCHEMA public;
 
 ## pg_statsinfo15からの変更点
 

--- a/doc/pg_statsinfo.md
+++ b/doc/pg_statsinfo.md
@@ -1373,7 +1373,17 @@ pg_controldata shows. Among the triplet, the host name of the master
 will generally be changed by a fail over so this situation happens.
 Currently there is no available means of preventing this occurring.
 
-  
+#### Q11. There's no plan statistics in a textual report although pg_stat_statements has been installed.
+
+pg_stat_statements may be installed in the schema other than "public". You
+will find the following lines in server log for the case.
+
+    ERROR: pg_statsinfo: query failed: ERROR: relation "pg_stat_statements" does not exist
+
+Do DROP EXTENSION, then CREATE EXTENSION again explicitly specifying
+public as installation schema in order to fix this.
+
+    CREATE EXTENSION pg_stat_statements SCHEMA public;
 
 ## Changes from pg_statsinfo15
 


### PR DESCRIPTION
…because I think the same note needs to be taken for pg_stat_statements where the same event occurs.