### PR TITLE
Fix wrong message for rusage_max changing.

### DIFF
--- a/agent/lib/last_xact_activity.c
+++ b/agent/lib/last_xact_activity.c
@@ -700,10 +700,10 @@ ru_check_stat_statements(void)
 		/* if rusage_max is smaller than pgss_max, use pgss_max. */
 		if (rusage_max < atoi(pgss_max))
 		{
-			rusage_max = atoi(pgss_max);
 			ereport(LOG,
-					errmsg("pg_statsinfo.rusage.max is changed from %d to %d.",
+					errmsg("pg_statsinfo.rusage_max is changed from %d to %d.",
 						rusage_max, atoi(pgss_max)));
+			rusage_max = atoi(pgss_max);
 		}
 	}
 }


### PR DESCRIPTION
Previously, when changing "pg_statsinfo.rusage_max" based on "pg_stat_statements.max",
the following message appeared. This was incorrect on the GUC name and the original value.

  LOG:  pg_statsinfo.rusage.max is changed from 10000 to 10000.